### PR TITLE
Update calendar module for Angular 17 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 # Support
 
 - ionic-angular `^3.0.0` [2.x](https://github.com/HsuanXyz/ion2-calendar/tree/v2)
-- @ionic/angular `4.0.0`
+- @ionic/angular `17.x`
 
 # Demo
 

--- a/dev/src/ion2-calendar/calendar.module.ts
+++ b/dev/src/ion2-calendar/calendar.module.ts
@@ -17,7 +17,6 @@ export function calendarController(modalCtrl: ModalController, calSvc: CalendarS
   imports: [CommonModule, IonicModule, FormsModule],
   declarations: CALENDAR_COMPONENTS,
   exports: CALENDAR_COMPONENTS,
-  entryComponents: CALENDAR_COMPONENTS,
   providers: [
     CalendarService,
     {
@@ -29,7 +28,7 @@ export function calendarController(modalCtrl: ModalController, calSvc: CalendarS
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class CalendarModule {
-  static forRoot(defaultOptions: CalendarModalOptions = {}): ModuleWithProviders {
+  static forRoot(defaultOptions: CalendarModalOptions = {}): ModuleWithProviders<CalendarModule> {
     return {
       ngModule: CalendarModule,
       providers: [

--- a/dev/src/ion2-calendar/components/calendar.modal.ts
+++ b/dev/src/ion2-calendar/components/calendar.modal.ts
@@ -9,7 +9,7 @@ import {
   AfterViewInit,
   HostBinding,
 } from '@angular/core';
-import { NavParams, ModalController, IonContent } from '@ionic/angular';
+import { ModalController, IonContent } from '@ionic/angular';
 import { CalendarDay, CalendarMonth, CalendarModalOptions } from '../calendar.model';
 import { CalendarService } from '../services/calendar.service';
 import * as moment from 'moment';
@@ -105,7 +105,6 @@ export class CalendarModal implements OnInit, AfterViewInit {
   constructor(
     private _renderer: Renderer2,
     public _elementRef: ElementRef,
-    public params: NavParams,
     public modalCtrl: ModalController,
     public ref: ChangeDetectorRef,
     public calSvc: CalendarService

--- a/src/calendar.module.ts
+++ b/src/calendar.module.ts
@@ -17,7 +17,6 @@ export function calendarController(modalCtrl: ModalController, calSvc: CalendarS
   imports: [CommonModule, IonicModule, FormsModule],
   declarations: CALENDAR_COMPONENTS,
   exports: CALENDAR_COMPONENTS,
-  entryComponents: CALENDAR_COMPONENTS,
   providers: [
     CalendarService,
     {
@@ -29,7 +28,7 @@ export function calendarController(modalCtrl: ModalController, calSvc: CalendarS
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class CalendarModule {
-  static forRoot(defaultOptions: CalendarModalOptions = {}): ModuleWithProviders {
+  static forRoot(defaultOptions: CalendarModalOptions = {}): ModuleWithProviders<CalendarModule> {
     return {
       ngModule: CalendarModule,
       providers: [

--- a/src/components/calendar.modal.ts
+++ b/src/components/calendar.modal.ts
@@ -9,7 +9,7 @@ import {
   AfterViewInit,
   HostBinding,
 } from '@angular/core';
-import { NavParams, ModalController, IonContent } from '@ionic/angular';
+import { ModalController, IonContent } from '@ionic/angular';
 import { CalendarDay, CalendarMonth, CalendarModalOptions } from '../calendar.model';
 import { CalendarService } from '../services/calendar.service';
 import * as moment from 'moment';
@@ -105,7 +105,6 @@ export class CalendarModal implements OnInit, AfterViewInit {
   constructor(
     private _renderer: Renderer2,
     public _elementRef: ElementRef,
-    public params: NavParams,
     public modalCtrl: ModalController,
     public ref: ChangeDetectorRef,
     public calSvc: CalendarService


### PR DESCRIPTION
## Summary
- remove deprecated `NavParams` usage in CalendarModal
- drop `entryComponents` array
- type `ModuleWithProviders` generically for `CalendarModule`
- document new Ionic Angular 17 support

## Testing
- `npm run lint` *(fails: tslint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68496e3473408323ae270ca15573b90b